### PR TITLE
Added flag to disable basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ if 'heartbeat' in settings.INSTALLED_APPS:
 
   If you want a more detailed view of some custom checkers you MUST configure a
 custom profile for heartbeat in your settings.py. The profile should be
-a dictionary containing at least the basic auth credentials.
+a dictionary containing at least the basic auth credentials or the key `disable`
+set to `True` to disable basic authentication.
 
 e.g.:
 

--- a/src/heartbeat/auth.py
+++ b/src/heartbeat/auth.py
@@ -12,11 +12,12 @@ def auth(func):
     @wraps(func)
     def _decorator(request, *args, **kwargs):
         auth = get_auth()
+        if auth.get('disable', False) is True:
+            return func(request, *args, **kwargs)
         if 'authorized_ips' in auth:
             ip = get_client_ip(request)
             if ip in auth['authorized_ips']:
                 return func(request, *args, **kwargs)
-
         prepare_credentials(auth)
         if request.META.get('HTTP_AUTHORIZATION'):
             authmeth, auth = request.META['HTTP_AUTHORIZATION'].split(' ')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -75,6 +75,17 @@ class TestDetailsView:
                'for heartbeat')
         assert msg == str(e.value)
 
+    def test_disabled_auth(self):
+        self.heartbeat['auth'] = {'disable': True}
+        # Make factory without auth header
+        self.factory = RequestFactory()
+        request = self.factory.get(reverse('1337'))
+        response = details(request)
+        assert response.status_code == 200
+        assert response['content-type'] == 'application/json'
+        json_response = json.loads(response.content.decode('utf-8'))
+        assert json_response['checkers']['test_views']['ping'] == 'pong'
+
     def test(self):
         self.heartbeat['auth'].update({'username': 'blow', 'password': 'fish'})
         request = self.factory.get(


### PR DESCRIPTION
This optionally disable basic auth while still allowing for allowed_ips to work.