### PR TITLE
Use pkg_resources for distributions listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,88 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/src/heartbeat/checkers/distribution_list.py
+++ b/src/heartbeat/checkers/distribution_list.py
@@ -1,8 +1,8 @@
-from pip import get_installed_distributions
+from pkg_resources import WorkingSet
 
 
 def check(request):
     return [
-            {'name': i.project_name, 'version': i.version} for i in
-            get_installed_distributions()
-        ]
+        {'name': distribution.project_name, 'version': distribution.version}
+        for distribution in WorkingSet()
+    ]

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -62,7 +62,7 @@ class TestCheckers(object):
         assert debug == mode
 
     @mock.patch(
-        'heartbeat.checkers.distribution_list.get_installed_distributions')
+        'heartbeat.checkers.distribution_list.WorkingSet')
     def test_get_distribution_list(self, dist_list):
         dist_list.return_value = [
             Mock(project_name=i, version='1.0.0') for i in range(3)]


### PR DESCRIPTION
Replaced get_installed_distributions with pkg_resources.WorkingSet
* since we're already using pkg_resources to check for a specific build we should be consistent and use pkg_resources to fetch all installed distributions
* pkg_resources should be preferred in favor of pip's get_installed_distributions. This method is still using pkg_resources at it's core to get the distributions but it does some filtering which is different from one pip version to another. Installed distributions should not vary from one pip version to another.